### PR TITLE
feat: add atlas trimming functionality

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -94,7 +94,7 @@ jobs:
         run: |
           cat > cordova/config.xml <<EOF
           <?xml version='1.0' encoding='utf-8'?>
-          <widget id="io.spritex.app" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+          <widget id="io.spritex.app" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
               <name>SpriteX</name>
               <description>A sample Apache Cordova application that responds to the deviceready event.</description>
               <author email="dev@cordova.apache.org" href="https://cordova.apache.org">


### PR DESCRIPTION
Adds a "Trim Atlas" button to the UI, which appears when an atlas with a width of 2048px is loaded.

When clicked, the button triggers a function that trims any empty space from the right side of the atlas.

The trimmed atlas can then be saved to the Firebase Realtime Database.

The `createAtlasJson` function was also modified to ensure that newly built atlases are consistently 2048px wide, making the feature testable and the atlas creation process more predictable.

fix: correct Android build by adding namespace

The Android build was failing due to a missing `xmlns:android` namespace in the generated `cordova/config.xml`. This change adds the required namespace to the `<widget>` tag in the GitHub workflow file, resolving the XML parsing error.