### PR TITLE
This commit introduces dynamic resizing for all preview containers to…

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,8 +219,9 @@
         border-color: var(--link-color);
       }
       .preview-container {
-        width: 128px;
-        height: 128px;
+        min-width: 128px;
+        min-height: 128px;
+        max-width: 100%;
         border: 1px solid var(--panel-border);
         display: flex;
         align-items: center;


### PR DESCRIPTION
… better accommodate sprites and animations of various sizes.

The following changes have been made:

1.  **Flexible CSS:** The `.preview-container` class in `index.html` has been updated to use `min-width` and `min-height` instead of fixed dimensions. This allows the containers to expand.

2.  **Dynamic Resizing Logic:** A new `setContainerSize` helper function has been added to `main.ts`. This function calculates the maximum dimensions of a set of images and applies them to the container's style.

3.  **Integration:** The `setContainerSize` function has been integrated into all four preview functions (`startSelectionPreview`, `startAtlasPreview`, `loadCharacterAndPreview`, and the single sprite preview dropdown) to enable dynamic resizing based on the content.