### PR TITLE
Add Atlas/Font builder mode and fixed-size centered frame packing

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,7 +386,7 @@
 
     <div class="panel grid-2">
       <div>
-        <div class="subtitle">Save Sprites to Firebase</div>
+        <div class="subtitle" id="spriteSaveSubtitle">Save Sprites to Firebase</div>
         <div class="row">
           <input
             id="spriteNamePrefix"
@@ -401,7 +401,14 @@
       </div>
 
       <div>
-        <div class="subtitle">Atlas Builder</div>
+        <div class="row" style="margin-bottom: 8px;">
+          <label for="builderTypeSelect">Builder</label>
+          <select id="builderTypeSelect" style="min-width: 170px;">
+            <option value="atlas">Atlas Builder</option>
+            <option value="font">Font Builder</option>
+          </select>
+        </div>
+        <div class="subtitle" id="builderSubtitle">Atlas Builder</div>
         <div class="row" style="margin-bottom: 8px;">
             <select id="atlasSelect">
               <option value="">-- Select an atlas --</option>


### PR DESCRIPTION
### Motivation
- Provide a toggle so users can choose between an Atlas Builder and a Font Builder workflow in the UI. 
- When using Font Builder, the JSON output should be a Phaser 4 RetroFont-style config (phaser4.0.0-rc6) rather than the normal atlas JSON. 
- Ensure generated spritesheets pack frames into uniform cells and center each source image so font glyphs / frames are consistent size.

### Description
- Added a `Builder` selector to the UI (`index.html`) with IDs `builderTypeSelect`, `spriteSaveSubtitle`, and `builderSubtitle` to support dynamic label/placeholder updates. 
- Implemented builder-mode logic in `src/main.ts`: added `getBuilderMode`, `applyBuilderModeUI`, and `getFontConfigText`, and store mode-specific output in `img._atlasOutputJson` so downloads and RTDB saves use the font config when `font` mode is selected. 
- Modified save/download flows to use the mode-specific output (`_atlasOutputJson`) for `downloadAtlasJson` and `saveAtlas` so font config is downloaded/saved when requested. 
- Normalized atlas packing in `src/atlasManager.ts` by computing a shared cell size (max width/height across sprites), storing centering offsets in `spriteSourceSize`, using that cell size for every frame, and drawing each source centered into its cell when building the atlas PNG. 

### Testing
- Built the web bundle with `npm run build` (esbuild) to verify TypeScript bundling and the new code compiles successfully. — Success. 
- Launched a static server and used an automated Playwright script to open the app, switch the `builderTypeSelect` to `font`, and capture a screenshot to validate the UI updates; the screenshot artifact `artifacts/builder-mode-font.png` was produced. — Success. 
- Verified that the app's atlas build/save/download flows now produce the alternative JSON output for font mode and continue to produce the original atlas json/png in atlas mode by inspecting the stored `_atlasOutputJson` and the downloaded content during manual validation in the automated run. — Success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ac15d07e083328e750a259517074a)