### PR TITLE
Add CLI atlas downloader for gameName/atlasName requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build:web": "esbuild src/main.ts --bundle --sourcemap --minify --format=esm --platform=browser --outdir=dist/assets --external:https://www.gstatic.com/*",
     "copy": "node scripts/copy-static.mjs",
-    "build": "npm run build:web && npm run copy"
+    "build": "npm run build:web && npm run copy",
+    "download:atlas": "node scripts/download-atlas.mjs"
   },
   "devDependencies": {
     "esbuild": "^0.21.5",

--- a/scripts/download-atlas.mjs
+++ b/scripts/download-atlas.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const DATABASE_URL = "https://evil-invaders-default-rtdb.firebaseio.com";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith("--")) continue;
+    const key = token.slice(2);
+    const value = argv[i + 1];
+    if (!value || value.startsWith("--")) {
+      args[key] = "true";
+    } else {
+      args[key] = value;
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function normalizeGameName(gameName) {
+  return gameName.replace(/-phaser\d+$/i, "");
+}
+
+function normalizeAtlasName(atlasName) {
+  if (atlasName === "game_asset") return "game_ui";
+  return atlasName;
+}
+
+function decodeBase64Png(raw) {
+  const cleaned = raw.replace(/^data:image\/png;base64,/, "");
+  return Buffer.from(cleaned, "base64");
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const gameName = args.gameName;
+  const atlasName = args.atlasName;
+  const outDir = args.outDir || "downloads";
+
+  if (!gameName || !atlasName) {
+    console.error(
+      "Usage: node scripts/download-atlas.mjs --gameName <name> --atlasName <name> [--outDir <dir>]"
+    );
+    process.exit(1);
+  }
+
+  const normalizedGameName = normalizeGameName(gameName);
+  const normalizedAtlasName = normalizeAtlasName(atlasName);
+  const rtdbPath = `games/${normalizedGameName}/atlases/${normalizedAtlasName}`;
+  const url = `${DATABASE_URL}/${rtdbPath}.json`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`RTDB request failed (${response.status} ${response.statusText})`);
+  }
+
+  const atlas = await response.json();
+  if (!atlas || typeof atlas !== "object") {
+    throw new Error(`No atlas found at ${rtdbPath}`);
+  }
+
+  const pngRaw = atlas.png;
+  const jsonRaw = atlas.json;
+
+  if (typeof pngRaw !== "string") {
+    throw new Error(`Missing png base64 at ${rtdbPath}/png`);
+  }
+
+  if (jsonRaw == null) {
+    throw new Error(`Missing json payload at ${rtdbPath}/json`);
+  }
+
+  const pngBuffer = decodeBase64Png(pngRaw);
+
+  let jsonText;
+  if (typeof jsonRaw === "string") {
+    try {
+      jsonText = `${JSON.stringify(JSON.parse(jsonRaw), null, 2)}\n`;
+    } catch {
+      jsonText = `${jsonRaw}\n`;
+    }
+  } else {
+    jsonText = `${JSON.stringify(jsonRaw, null, 2)}\n`;
+  }
+
+  const outputDirectory = path.resolve(outDir);
+  await mkdir(outputDirectory, { recursive: true });
+
+  const pngFilePath = path.join(outputDirectory, `${normalizedAtlasName}.png`);
+  const jsonFilePath = path.join(outputDirectory, `${normalizedAtlasName}.json`);
+
+  await writeFile(pngFilePath, pngBuffer);
+  await writeFile(jsonFilePath, jsonText, "utf8");
+
+  console.log(
+    JSON.stringify(
+      {
+        gameName,
+        atlasName,
+        normalizedGameName,
+        normalizedAtlasName,
+        rtdbPath,
+        files: {
+          png: pngFilePath,
+          json: jsonFilePath,
+        },
+      },
+      null,
+      2
+    )
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Provide a simple CLI that Claude skill or other automation can call with `gameName` and `atlasName` to retrieve atlas payloads from the project's Firebase RTDB and produce downloadable files.
- Normalize external skill inputs (e.g., `evil-invaders-phaser4` and `game_asset`) to the RTDB keys used by the project.

### Description
- Add `scripts/download-atlas.mjs` which accepts `--gameName` and `--atlasName`, normalizes inputs, fetches `games/<normalizedGame>/atlases/<normalizedAtlas>` from the RTDB, decodes the `png` base64 and writes `<atlas>.png` and `<atlas>.json` to disk, and prints a JSON summary of results.
- Normalization rules implemented are `gameName.replace(/-phaser\d+$/i, "")` and `atlasName === "game_asset" -> "game_ui"`.
- The script decodes `data:image/png;base64,...` to binary using `Buffer.from(...)` and pretty-prints or preserves the `json` payload depending on its stored type.
- Add an npm script `download:atlas` so the tool can be invoked with `npm run download:atlas -- --gameName ... --atlasName ...`.

### Testing
- Ran `node --check scripts/download-atlas.mjs` which passed syntax checks successfully.
- Ran `npm run build` to ensure the repo still builds successfully and it passed (`esbuild` bundle created).
- Attempted `npm run download:atlas -- --gameName evil-invaders-phaser4 --atlasName game_asset --outDir tmp-downloads` and the RTDB fetch failed in this environment (`fetch failed`), but the script wiring and error handling executed as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b7afc977c83328521e1e93ad6f70d)