### PR TITLE
Make download:atlas support atlas-only lookups

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build:web": "esbuild src/main.ts --bundle --sourcemap --minify --format=esm --platform=browser --outdir=dist/assets --external:https://www.gstatic.com/*",
     "copy": "node scripts/copy-static.mjs",
-    "build": "npm run build:web && npm run copy"
+    "build": "npm run build:web && npm run copy",
+    "download:atlas": "node scripts/download-atlas.mjs"
   },
   "devDependencies": {
     "esbuild": "^0.21.5",

--- a/scripts/download-atlas.mjs
+++ b/scripts/download-atlas.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const DATABASE_URL = "https://evil-invaders-default-rtdb.firebaseio.com";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith("--")) continue;
+    const key = token.slice(2);
+    const value = argv[i + 1];
+    if (!value || value.startsWith("--")) {
+      args[key] = "true";
+    } else {
+      args[key] = value;
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function normalizeGameName(gameName) {
+  return gameName.replace(/-phaser\d+$/i, "");
+}
+
+function normalizeAtlasName(atlasName) {
+  if (atlasName === "game_asset") return "game_ui";
+  return atlasName;
+}
+
+function decodeBase64Png(raw) {
+  const cleaned = raw.replace(/^data:image\/png;base64,/, "");
+  return Buffer.from(cleaned, "base64");
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const gameName = args.gameName;
+  const atlasName = args.atlasName;
+  const outDir = args.outDir || "downloads";
+
+  if (!atlasName) {
+    console.error(
+      "Usage: node scripts/download-atlas.mjs --atlasName <name> [--gameName <name>] [--outDir <dir>]"
+    );
+    process.exit(1);
+  }
+
+  const normalizedGameName = gameName ? normalizeGameName(gameName) : null;
+  const normalizedAtlasName = normalizeAtlasName(atlasName);
+  const rtdbPath = normalizedGameName
+    ? `games/${normalizedGameName}/atlases/${normalizedAtlasName}`
+    : `atlases/${normalizedAtlasName}`;
+  const url = `${DATABASE_URL}/${rtdbPath}.json`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`RTDB request failed (${response.status} ${response.statusText})`);
+  }
+
+  const atlas = await response.json();
+  if (!atlas || typeof atlas !== "object") {
+    throw new Error(`No atlas found at ${rtdbPath}`);
+  }
+
+  const pngRaw = atlas.png;
+  const jsonRaw = atlas.json;
+
+  if (typeof pngRaw !== "string") {
+    throw new Error(`Missing png base64 at ${rtdbPath}/png`);
+  }
+
+  if (jsonRaw == null) {
+    throw new Error(`Missing json payload at ${rtdbPath}/json`);
+  }
+
+  const pngBuffer = decodeBase64Png(pngRaw);
+
+  let jsonText;
+  if (typeof jsonRaw === "string") {
+    try {
+      jsonText = `${JSON.stringify(JSON.parse(jsonRaw), null, 2)}\n`;
+    } catch {
+      jsonText = `${jsonRaw}\n`;
+    }
+  } else {
+    jsonText = `${JSON.stringify(jsonRaw, null, 2)}\n`;
+  }
+
+  const outputDirectory = path.resolve(outDir);
+  await mkdir(outputDirectory, { recursive: true });
+
+  const pngFilePath = path.join(outputDirectory, `${normalizedAtlasName}.png`);
+  const jsonFilePath = path.join(outputDirectory, `${normalizedAtlasName}.json`);
+
+  await writeFile(pngFilePath, pngBuffer);
+  await writeFile(jsonFilePath, jsonText, "utf8");
+
+  console.log(
+    JSON.stringify(
+      {
+        gameName,
+        atlasName,
+        normalizedGameName,
+        normalizedAtlasName,
+        rtdbPath,
+        files: {
+          png: pngFilePath,
+          json: jsonFilePath,
+        },
+      },
+      null,
+      2
+    )
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Allow the atlas downloader to be used without a `--gameName` so standalone atlases (e.g. `atlases/game_ui`) can be fetched directly. 
- Keep existing behavior when `--gameName` is provided so game-scoped atlases remain accessible. 
- Provide a simple CLI entrypoint via `npm run download:atlas` for automation and other skills to call.

### Description
- Updated `scripts/download-atlas.mjs` to require only `--atlasName` and make `--gameName` optional, updating the usage text accordingly. 
- Implemented RTDB path fallback so the script uses `games/<normalizedGame>/atlases/<normalizedAtlas>` when `--gameName` is present and `atlases/<normalizedAtlas>` when omitted. 
- Preserved existing normalization (`-phaserN` trimming and `game_asset -> game_ui` mapping), base64 PNG decoding, and JSON handling logic. 
- Added an npm script `download:atlas` in `package.json` that runs `node scripts/download-atlas.mjs`.

### Testing
- Ran `node --check scripts/download-atlas.mjs` which passed syntax checks. 
- Ran `npm run build` which completed successfully. 
- Ran `npm run download:atlas -- --atlasName game_asset --outDir tmp-downloads`, which exercised the script but the network fetch failed in this environment (output: `fetch failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b7afc977c83328521e1e93ad6f70d)