### PR TITLE
Add Atlas import modal with file upload and drag-and-drop support

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,6 +287,38 @@
         font-weight: 600;
         margin-bottom: 6px;
       }
+      .modal {
+        position: fixed;
+        inset: 0;
+        display: none;
+        align-items: center;
+        justify-content: center;
+        background: rgba(0, 0, 0, 0.55);
+        z-index: 1000;
+      }
+      .modal.open {
+        display: flex;
+      }
+      .modal-content {
+        width: min(560px, 92vw);
+        background: var(--panel-bg);
+        border: 1px solid var(--panel-border);
+        border-radius: 8px;
+        padding: 14px;
+      }
+      .dropzone {
+        margin-top: 8px;
+        border: 2px dashed var(--panel-border);
+        border-radius: 8px;
+        padding: 20px;
+        text-align: center;
+        color: var(--tip-text);
+      }
+      .dropzone.active {
+        border-color: var(--accent);
+        color: var(--text-color);
+        background: color-mix(in srgb, var(--accent) 12%, transparent);
+      }
     </style>
   </head>
   <body>
@@ -426,6 +458,7 @@
             placeholder="Atlas name (e.g., enemy_atlas)"
           />
           <button id="buildAtlasBtn" class="btn">Build Atlas</button>
+          <button id="openImportAtlasModalBtn" class="btn">Import Atlas</button>
           <button id="trimAtlasBtn" class="btn" style="display: none;">Trim Atlas</button>
           <button id="saveAtlasFirebaseBtn" class="btn" disabled>
             Save Atlas (RTDB)
@@ -507,6 +540,28 @@
               alt="Character Preview"
             />
           </div>
+      </div>
+    </div>
+
+    <div id="importAtlasModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="importAtlasTitle">
+      <div class="modal-content">
+        <div class="row" style="justify-content: space-between; align-items: center; margin-bottom: 8px;">
+          <strong id="importAtlasTitle">Import Atlas</strong>
+          <button id="closeImportAtlasModalBtn" class="btn" type="button">Close</button>
+        </div>
+        <div class="row">
+          <input id="importAtlasJsonInput" type="file" accept=".json,application/json" />
+          <input id="importAtlasPngInput" type="file" accept=".png,image/png" />
+        </div>
+        <div id="atlasImportDropzone" class="dropzone">
+          Drag & drop atlas JSON + PNG files here
+        </div>
+        <div id="atlasImportStatus" style="margin-top: 8px; color: var(--tip-text); font-size: 0.95em;">
+          Select both files to import.
+        </div>
+        <div class="row" style="margin-top: 10px; justify-content: flex-end;">
+          <button id="confirmImportAtlasBtn" class="btn" type="button">Import</button>
+        </div>
       </div>
     </div>
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,8 @@ let atlasAnimPlaying = false;
 let atlasReorderEnabled = false;
 let atlasOrderDirty = false;
 let atlasSyncPromise: Promise<void> | null = null;
+let importAtlasJsonFile: File | null = null;
+let importAtlasPngFile: File | null = null;
 
 // BG color eyedropper state
 let bgPickActive = false;
@@ -1316,46 +1318,145 @@ async function loadAtlasAndPreview() {
     }
 
     const { png: dataURL, json } = atlasData;
+    await applyAtlasPreview(dataURL, json, { selectAllFrames: true, startPreviewNow: true });
+}
 
-    const img = $("atlasPreviewImg") as HTMLImageElement;
-    img.src = dataURL;
+async function applyAtlasPreview(
+  dataURL: string,
+  json: any,
+  options?: { selectAllFrames?: boolean; startPreviewNow?: boolean; outputJson?: any }
+) {
+  const img = $("atlasPreviewImg") as HTMLImageElement;
+  img.src = dataURL;
 
-    (img as any)._atlasJson = json;
-    (img as any)._atlasDataURL = dataURL;
-    (img as any)._atlasOutputJson = json;
+  (img as any)._atlasJson = json;
+  (img as any)._atlasDataURL = dataURL;
+  (img as any)._atlasOutputJson = options?.outputJson ?? json;
 
-    const trimBtn = $("trimAtlasBtn") as HTMLButtonElement;
-    if (json?.meta?.size?.w === 2048) {
-        trimBtn.style.display = 'inline-block';
-    } else {
-        trimBtn.style.display = 'none';
+  const trimBtn = $("trimAtlasBtn") as HTMLButtonElement;
+  trimBtn.style.display = json?.meta?.size?.w === 2048 ? "inline-block" : "none";
+
+  $("saveAtlasFirebaseBtn")!.removeAttribute("disabled");
+  $("downloadAtlasJsonBtn")!.removeAttribute("disabled");
+  $("downloadAtlasPngBtn")!.removeAttribute("disabled");
+
+  stopAtlasPreview();
+  atlasSelectedFrameIndices.clear();
+
+  await new Promise<void>((resolve) => {
+    const atlasImg = new Image();
+    atlasImg.onload = async () => {
+      atlasFrames = await extractFramesFromAtlas(atlasImg, json);
+      atlasOrderDirty = false;
+      if (options?.selectAllFrames) {
+        atlasSelectedFrameIndices = new Set(atlasFrames.map((_, i) => i));
+      }
+      renderAtlasFrames();
+      if (options?.startPreviewNow) {
+        startAtlasPreview();
+      }
+      resolve();
+    };
+    atlasImg.onerror = () => {
+      console.error("Failed to load atlas image for preview");
+      resolve();
+    };
+    atlasImg.src = dataURL;
+  });
+}
+
+function readFileAsText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result || ""));
+    reader.onerror = () => reject(new Error(`Could not read ${file.name}.`));
+    reader.readAsText(file);
+  });
+}
+
+function readFileAsDataURL(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result || ""));
+    reader.onerror = () => reject(new Error(`Could not read ${file.name}.`));
+    reader.readAsDataURL(file);
+  });
+}
+
+function setAtlasImportStatus(message: string) {
+  const status = $("atlasImportStatus") as HTMLDivElement | null;
+  if (status) status.textContent = message;
+}
+
+function refreshImportAtlasStatus() {
+  const jsonLabel = importAtlasJsonFile ? `JSON: ${importAtlasJsonFile.name}` : "JSON: missing";
+  const pngLabel = importAtlasPngFile ? `PNG: ${importAtlasPngFile.name}` : "PNG: missing";
+  setAtlasImportStatus(`${jsonLabel} | ${pngLabel}`);
+}
+
+function clearImportAtlasState() {
+  importAtlasJsonFile = null;
+  importAtlasPngFile = null;
+  const jsonInput = $("importAtlasJsonInput") as HTMLInputElement | null;
+  const pngInput = $("importAtlasPngInput") as HTMLInputElement | null;
+  if (jsonInput) jsonInput.value = "";
+  if (pngInput) pngInput.value = "";
+  setAtlasImportStatus("Select both files to import.");
+}
+
+function setImportAtlasFile(file: File) {
+  const fileName = file.name.toLowerCase();
+  const isJson = file.type === "application/json" || fileName.endsWith(".json");
+  const isPng = file.type === "image/png" || fileName.endsWith(".png");
+
+  if (isJson) {
+    importAtlasJsonFile = file;
+  } else if (isPng) {
+    importAtlasPngFile = file;
+  }
+}
+
+function openImportAtlasModal() {
+  const modal = $("importAtlasModal") as HTMLDivElement | null;
+  modal?.classList.add("open");
+  refreshImportAtlasStatus();
+}
+
+function closeImportAtlasModal(reset = false) {
+  const modal = $("importAtlasModal") as HTMLDivElement | null;
+  modal?.classList.remove("open");
+  if (reset) clearImportAtlasState();
+}
+
+async function importAtlasFromSelectedFiles() {
+  if (!importAtlasJsonFile || !importAtlasPngFile) {
+    alert("Select both atlas JSON and PNG files.");
+    return;
+  }
+
+  try {
+    const [jsonText, dataURL] = await Promise.all([
+      readFileAsText(importAtlasJsonFile),
+      readFileAsDataURL(importAtlasPngFile),
+    ]);
+    const json = JSON.parse(jsonText);
+
+    if (!json?.frames || typeof json.frames !== "object") {
+      alert("Invalid atlas JSON. Missing frames object.");
+      return;
     }
 
-    $("saveAtlasFirebaseBtn")!.removeAttribute("disabled");
-    $("downloadAtlasJsonBtn")!.removeAttribute("disabled");
-    $("downloadAtlasPngBtn")!.removeAttribute("disabled");
+    const atlasNameInput = $("atlasNameInput") as HTMLInputElement | null;
+    if (atlasNameInput && !atlasNameInput.value.trim()) {
+      atlasNameInput.value = importAtlasJsonFile.name.replace(/\.json$/i, "");
+    }
 
-    // This part is the same as in buildAtlasAndPreview
-    stopAtlasPreview();
-    atlasSelectedFrameIndices.clear();
-
-    await new Promise<void>(resolve => {
-        const atlasImg = new Image();
-        atlasImg.onload = async () => {
-            atlasFrames = await extractFramesFromAtlas(atlasImg, json);
-            atlasOrderDirty = false;
-            // Select all frames by default
-            atlasSelectedFrameIndices = new Set(atlasFrames.map((_, i) => i));
-            renderAtlasFrames();
-            startAtlasPreview();
-            resolve();
-        };
-        atlasImg.onerror = () => {
-            console.error("Failed to load atlas image for preview");
-            resolve();
-        }
-        atlasImg.src = dataURL;
-    });
+    await applyAtlasPreview(dataURL, json, { selectAllFrames: true, startPreviewNow: true });
+    closeImportAtlasModal(true);
+  } catch (err: any) {
+    console.error(err);
+    alert(`Failed to import atlas: ${err?.message || "Unknown error"}`);
+  }
 }
 
 async function loadCharacterAndPreview() {
@@ -1697,6 +1798,68 @@ function wireUI() {
     "click",
     buildAtlasAndPreview
   );
+
+  ($("openImportAtlasModalBtn") as HTMLButtonElement)?.addEventListener(
+    "click",
+    () => openImportAtlasModal()
+  );
+
+  ($("closeImportAtlasModalBtn") as HTMLButtonElement)?.addEventListener(
+    "click",
+    () => closeImportAtlasModal(false)
+  );
+
+  ($("confirmImportAtlasBtn") as HTMLButtonElement)?.addEventListener(
+    "click",
+    importAtlasFromSelectedFiles
+  );
+
+  ($("importAtlasJsonInput") as HTMLInputElement)?.addEventListener("change", (ev) => {
+    const input = ev.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+    importAtlasJsonFile = file;
+    refreshImportAtlasStatus();
+  });
+
+  ($("importAtlasPngInput") as HTMLInputElement)?.addEventListener("change", (ev) => {
+    const input = ev.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+    importAtlasPngFile = file;
+    refreshImportAtlasStatus();
+  });
+
+  const dropzone = $("atlasImportDropzone") as HTMLDivElement | null;
+  if (dropzone) {
+    const setDropActive = (active: boolean) => dropzone.classList.toggle("active", active);
+
+    ["dragenter", "dragover"].forEach((eventName) => {
+      dropzone.addEventListener(eventName, (ev) => {
+        ev.preventDefault();
+        setDropActive(true);
+      });
+    });
+
+    ["dragleave", "dragend", "drop"].forEach((eventName) => {
+      dropzone.addEventListener(eventName, (ev) => {
+        ev.preventDefault();
+        setDropActive(false);
+      });
+    });
+
+    dropzone.addEventListener("drop", (ev) => {
+      const files = Array.from(ev.dataTransfer?.files || []);
+      files.forEach((file) => setImportAtlasFile(file));
+      refreshImportAtlasStatus();
+    });
+  }
+
+  ($("importAtlasModal") as HTMLDivElement | null)?.addEventListener("click", (ev) => {
+    if (ev.target === ev.currentTarget) {
+      closeImportAtlasModal(false);
+    }
+  });
 
   ($("trimAtlasBtn") as HTMLButtonElement).addEventListener(
     "click",


### PR DESCRIPTION
### Motivation
- Provide a convenient way to load existing atlas packages (JSON + PNG) into the Atlas Builder without requiring DB upload or URL loading.
- Unify the preview/load logic so imported atlases behave the same as DB-loaded atlases and built atlases.

### Description
- Added an `Import Atlas` button and a modal UI in `index.html` with JSON and PNG file inputs, a drag-and-drop dropzone, status text, and an `Import` action. (`index.html`) 
- Implemented file handling and import flow in `src/main.ts`, including `readFileAsText`, `readFileAsDataURL`, import state tracking, drag/drop handlers, and modal open/close helpers. (`src/main.ts`) 
- Introduced `applyAtlasPreview(dataURL, json, options)` to centralize atlas preview/setup (enables preview image, frame extraction, enabling save/download buttons, trim button logic, and optionally start preview). (`src/main.ts`) 
- Added validation of imported JSON (requires `frames` object) and minor UX updates (auto-fill atlas name input from JSON filename and refresh status text while selecting files). (`src/main.ts`, `index.html`)

### Testing
- Ran a production build with `npm run build` which completed successfully and produced bundled assets under `dist/assets`. ✅
- Automated UI smoke check via Playwright using Firefox succeeded and captured the open Import Atlas modal screenshot. ✅
- Playwright run using Chromium in the container crashed (segmentation fault in headless Chromium) but this did not affect the code build or the Firefox validation; Chromium failure is environment-related. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a36fcb45f0833282847e32f1ff4f94)