### PR TITLE
Encode atlas frame keys for Firebase RTDB and guard malformed atlas frames

### DIFF
--- a/src/atlasManager.ts
+++ b/src/atlasManager.ts
@@ -272,6 +272,18 @@ function ensureDataURL(s: string): string {
   return s.startsWith("data:") ? s : `data:image/png;base64,${s}`;
 }
 
+/** Firebase RTDB keys cannot contain . # $ / [ ] */
+function encodeAtlasFrameKey(name: string): string {
+  return `k_${Array.from(name)
+    .map((ch) => ch.codePointAt(0)!.toString(16).padStart(4, "0"))
+    .join("")}`;
+}
+
+function getAtlasFrameEntry(framesMap: any, frameName: string): any | null {
+  if (!framesMap || typeof framesMap !== "object") return null;
+  return framesMap[frameName] ?? framesMap[encodeAtlasFrameKey(frameName)] ?? null;
+}
+
 /** Some atlases store json as string. Handle object or (single/double) string. */
 function normalizeAtlasJson(jsonVal: any): any | null {
   if (jsonVal == null) return null;
@@ -554,7 +566,8 @@ export function createAtlasJson(
     const offsetX = Math.floor((frameWidth - dimensions.width) / 2);
     const offsetY = Math.floor((frameHeight - dimensions.height) / 2);
 
-    frames[name] = {
+    const key = encodeAtlasFrameKey(name);
+    frames[key] = {
       frame: {
         x: currentX,
         y: currentY,
@@ -608,7 +621,7 @@ export async function createAtlasPng(
     return new Promise<void>((resolve) => {
       const img = new Image();
       img.onload = () => {
-        const frame = atlasJson.frames[name];
+        const frame = getAtlasFrameEntry(atlasJson.frames, name);
         if (frame) {
           const drawX = frame.frame.x + (frame.spriteSourceSize?.x ?? 0);
           const drawY = frame.frame.y + (frame.spriteSourceSize?.y ?? 0);
@@ -774,7 +787,7 @@ export async function loadCharacterPreviewFromAtlas(
   // Slice frames
   const frames: string[] = [];
   for (const key of textures) {
-    const f = framesMap[key];
+    const f = getAtlasFrameEntry(framesMap, key);
     if (!f || !f.frame) continue;
     const { x, y, w, h } = f.frame;
     const c = document.createElement("canvas");
@@ -798,7 +811,7 @@ export function validateCharacterFrames(
   const atlasFrames =
     atlasJson.frames || atlasJson.textures?.[0]?.frames || {};
   character.texture.forEach((name) => {
-    if (!atlasFrames[name]) missing.push(name);
+    if (!getAtlasFrameEntry(atlasFrames, name)) missing.push(name);
   });
   return missing;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -718,7 +718,10 @@ async function extractFramesFromAtlas(
   const frameData = atlasJson.frames || {};
 
   for (const key in frameData) {
-    const frame = frameData[key].frame;
+    const frame = frameData[key]?.frame;
+    if (!frame || typeof frame.w !== "number" || typeof frame.h !== "number") {
+      continue;
+    }
     const c = document.createElement("canvas");
     c.width = frame.w;
     c.height = frame.h;


### PR DESCRIPTION
### Motivation
- Firebase RTDB rejects keys containing characters like `.` or `/`, which caused save failures for atlas frames named e.g. `twitterBtn0.gif`; additionally, UI frame extraction crashed with `Cannot read properties of undefined (reading 'w')` when atlas entries were malformed.

### Description
- Added `encodeAtlasFrameKey` to produce RTDB-safe frame keys and switched `createAtlasJson` to emit encoded keys instead of raw names.
- Added `getAtlasFrameEntry` to resolve either the original or encoded frame key and used it in `createAtlasPng`, `loadCharacterPreviewFromAtlas`, and `validateCharacterFrames` so existing `character.texture` references keep working.
- Hardened `extractFramesFromAtlas` in `src/main.ts` to skip entries that lack a valid `frame` object or numeric `w`/`h` values to avoid runtime `TypeError` during slicing.
- Kept `normalizeAtlasJson`/`ensureDataURL` behavior and ensured atlas PNG composition and slicing use the shared lookup helper.

### Testing
- Ran `npm run build` and the project built successfully producing `dist/assets/main.js` without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a38fc6084c8332b50c46380c21eb39)