### PR TITLE
Fix atlas frame key encoding for astral characters (emoji)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "copy": "node scripts/copy-static.mjs",
     "build": "npm run build:web && npm run copy",
     "download:atlas": "node scripts/download-atlas.mjs",
-    "extract:frames": "node scripts/extract-frames.mjs"
+    "extract:frames": "node scripts/extract-frames.mjs",
+    "test": "node scripts/test-frame-keys.mjs"
   },
   "devDependencies": {
     "esbuild": "^0.21.5",

--- a/scripts/extract-frames.mjs
+++ b/scripts/extract-frames.mjs
@@ -21,6 +21,7 @@
 
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { createCanvas, loadImage } from "./canvas-shim.mjs";
 
 const DATABASE_URL = "https://evil-invaders-default-rtdb.firebaseio.com";
@@ -65,7 +66,7 @@ function normalizeAtlasJson(jsonVal) {
   }
 }
 
-function decodeFrameKey(key) {
+export function decodeFrameKey(key) {
   if (!key.startsWith("k_")) return key;
   const hex = key.slice(2);
   let result = "";
@@ -75,10 +76,15 @@ function decodeFrameKey(key) {
   return result;
 }
 
-function encodeFrameKey(name) {
-  return `k_${Array.from(name)
-    .map((ch) => ch.codePointAt(0).toString(16).padStart(4, "0"))
-    .join("")}`;
+export function encodeFrameKey(name) {
+  // Encode UTF-16 code units, not code points: decodeFrameKey slices the hex
+  // in fixed 4-digit chunks, and astral chars (emoji) would emit 5-digit
+  // groups that break the round-trip.
+  let hex = "";
+  for (let i = 0; i < name.length; i += 1) {
+    hex += name.charCodeAt(i).toString(16).padStart(4, "0");
+  }
+  return `k_${hex}`;
 }
 
 /** Get the frames map from an atlas JSON (handles both flat and textures[] formats). */
@@ -305,7 +311,12 @@ async function main() {
   );
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : error);
-  process.exit(1);
-});
+const runAsCli =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (runAsCli) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/scripts/test-frame-keys.mjs
+++ b/scripts/test-frame-keys.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * test-frame-keys.mjs
+ *
+ * Round-trip checks for the hex frame-key encoding shared by
+ * scripts/extract-frames.mjs, scripts/download-atlas.mjs, and
+ * src/atlasManager.ts / src/main.ts.
+ *
+ * Usage: npm test
+ */
+
+import assert from "node:assert/strict";
+import { decodeFrameKey, encodeFrameKey } from "./extract-frames.mjs";
+
+// Astral characters (emoji, U+10000+) must round-trip. They encode as two
+// 4-hex-digit UTF-16 surrogate groups; the old per-code-point encoding
+// emitted a 5-digit group that decoders could not re-chunk.
+for (const name of ["boss💥.png", "😀", "explosion🎮/frame.0"]) {
+  assert.equal(decodeFrameKey(encodeFrameKey(name)), name, `round-trip failed for ${name}`);
+}
+
+// BMP-only names must keep their existing encoding byte-identical, so keys
+// already stored in RTDB still match.
+const legacyEncode = (name) =>
+  `k_${Array.from(name)
+    .map((ch) => ch.codePointAt(0).toString(16).padStart(4, "0"))
+    .join("")}`;
+for (const name of ["player/idle_0.png", "enemy.boss[1]", "sprite#2$", "ünïcode™"]) {
+  assert.equal(encodeFrameKey(name), legacyEncode(name), `BMP encoding changed for ${name}`);
+  assert.equal(decodeFrameKey(encodeFrameKey(name)), name, `round-trip failed for ${name}`);
+}
+
+// Keys without the k_ prefix pass through decode untouched.
+assert.equal(decodeFrameKey("plain_key"), "plain_key");
+
+console.log("frame-key tests passed");

--- a/src/atlasManager.ts
+++ b/src/atlasManager.ts
@@ -278,9 +278,14 @@ function ensureDataURL(s: string): string {
 
 /** Firebase RTDB keys cannot contain . # $ / [ ] */
 function encodeAtlasFrameKey(name: string): string {
-  return `k_${Array.from(name)
-    .map((ch) => ch.codePointAt(0)!.toString(16).padStart(4, "0"))
-    .join("")}`;
+  // Encode UTF-16 code units, not code points: decoders slice the hex in fixed
+  // 4-digit chunks, and astral chars (emoji) would emit 5-digit groups that
+  // break the round-trip. Surrogate pairs become two 4-digit groups instead.
+  let hex = "";
+  for (let i = 0; i < name.length; i++) {
+    hex += name.charCodeAt(i).toString(16).padStart(4, "0");
+  }
+  return `k_${hex}`;
 }
 
 const RTDB_INVALID_KEY_CHARS = /[.#$\/\[\]]/;


### PR DESCRIPTION
## Summary
- `encodeAtlasFrameKey` (src/atlasManager.ts) encoded per *code point*, so any astral character (emoji, U+10000+) emitted a 5-hex-digit group. The decoders in src/main.ts and the CLI scripts slice the hex in fixed 4-digit chunks, so such keys decoded to garbage — the frame was silently renamed on the next save.
- Fix: encode UTF-16 code units (`charCodeAt` over an index loop, always 4 hex digits). BMP-only keys stay byte-identical to what's already stored in RTDB; surrogate pairs become two 4-digit groups that the existing decoders already reassemble correctly, so no decoder changes were needed.
- Applied the same fix to the duplicate encoder in `scripts/extract-frames.mjs`, exported its encode/decode helpers, and guarded the CLI entry with an `import.meta.url` check so the module is importable.
- Added `scripts/test-frame-keys.mjs` (wired up as `npm test`): emoji round-trip, BMP back-compat (new encoding === old encoding), and non-`k_` key passthrough.

## Test plan
- [x] `npm test` passes
- [x] `npm run build:web` bundles cleanly
- [x] `node scripts/extract-frames.mjs` with no args still prints usage and exits 1 (CLI guard intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)